### PR TITLE
Dspace 7.6 Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- JAXB is no longer bundled for java 11
              compile only as this will be brought in through dspace-api in 7.x -->

--- a/src/test/java/org/dspace/TestContentServiceFactory.java
+++ b/src/test/java/org/dspace/TestContentServiceFactory.java
@@ -31,8 +31,8 @@ import org.dspace.content.service.MetadataValueService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.RelationshipTypeService;
 import org.dspace.content.service.SiteService;
-import org.dspace.content.service.SupervisedItemService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.eperson.service.SubscribeService;
 
 /**
  * A {@link ContentServiceFactory} which returns mock services
@@ -119,13 +119,13 @@ public class TestContentServiceFactory extends ContentServiceFactory {
     }
 
     @Override
-    public SupervisedItemService getSupervisedItemService() {
-        throw new UnsupportedOperationException();
+    public SiteService getSiteService() {
+        return siteService;
     }
 
     @Override
-    public SiteService getSiteService() {
-        return siteService;
+    public SubscribeService getSubscribeService() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/org/dspace/TestEPersonServiceFactory.java
+++ b/src/test/java/org/dspace/TestEPersonServiceFactory.java
@@ -15,7 +15,6 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.eperson.service.RegistrationDataService;
 import org.dspace.eperson.service.SubscribeService;
-import org.dspace.eperson.service.SupervisorService;
 
 /**
  * {@link EPersonServiceFactory} for testing
@@ -52,8 +51,4 @@ public class TestEPersonServiceFactory extends EPersonServiceFactory {
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public SupervisorService getSupervisorService() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/src/test/java/org/dspace/pack/bagit/BagItPackerTest.java
+++ b/src/test/java/org/dspace/pack/bagit/BagItPackerTest.java
@@ -42,7 +42,7 @@ import org.junit.Before;
 
 /**
  * Base class for all BagIt packing/unpacking tests. This performs initial setup so that the DSpaceKernel is not null
- * and so that some of the that are used through static contexts or have static initializers (e.g.
+ * and so that classes used through static contexts or have static initializers (e.g.
  * {@link org.dspace.services.factory.DSpaceServicesFactory}, {@link org.dspace.core.Context}) can initialize and
  * retrieve any classes which are necessary for basic operations.
  *


### PR DESCRIPTION
A few minor updates to allow compilation with DSpace 7.6.

The only thing that might need some discussion is the additions of the log4j dependencies. `log4j-core` should be fine since it's only needed for testing, but `log4j-api` is needed for compilation and might need to be excluded when bundling with DSpace. I haven't had time to check if there are DSpace dependencies we could get these from, or at something least to keep the version consistent.

@nwoodward I still need to test these changes when deployed with DSpace. I talked to Danny earlier and we were thinking of doing that with the Duracloud sprint later in the month. I just wanted to get ahead of things with this PR in case there are any changes which seem out of place.